### PR TITLE
Added QRDataListener.onReadQrError(Exception) callback for error handling

### DIFF
--- a/app/src/main/java/github/nisrulz/projectqreader/MainActivity.java
+++ b/app/src/main/java/github/nisrulz/projectqreader/MainActivity.java
@@ -24,6 +24,8 @@ import android.view.View;
 import android.view.ViewTreeObserver;
 import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Toast;
+
 import github.nisrulz.qreader.QRDataListener;
 import github.nisrulz.qreader.QREader;
 
@@ -93,5 +95,9 @@ public class MainActivity extends AppCompatActivity implements QRDataListener {
         text.setText(data);
       }
     });
+  }
+
+  @Override public void onReadQrError(final Exception exception) {
+    Toast.makeText(this, "Cannot open camera", Toast.LENGTH_LONG).show();
   }
 }

--- a/library/src/main/java/github/nisrulz/qreader/QRDataListener.java
+++ b/library/src/main/java/github/nisrulz/qreader/QRDataListener.java
@@ -18,6 +18,9 @@ package github.nisrulz.qreader;
 
 public interface QRDataListener {
 
-    // Called from not main thread. Be careful
+    // Called NOT on the main thread. Be careful
     void onDetected(final String data);
+
+    // Called on the main thread
+    void onReadQrError(final Exception exception);
 }

--- a/library/src/main/java/github/nisrulz/qreader/QREader.java
+++ b/library/src/main/java/github/nisrulz/qreader/QREader.java
@@ -62,7 +62,13 @@ public class QREader {
     @Override public void surfaceCreated(SurfaceHolder surfaceHolder) {
       //we can start barcode after after creating
       surfaceCreated = true;
-      startCameraView(context, cameraSource, surfaceView);
+      try {
+        startCameraView(context, cameraSource, surfaceView);
+      } catch (Exception e) {
+        surfaceCreated = false;
+        stop();
+        qrDataListener.onReadQrError(e);
+      }
     }
 
     @Override public void surfaceChanged(SurfaceHolder surfaceHolder, int i, int i1, int i2) {


### PR DESCRIPTION
Currently it is called on failed to open camera, which will happen when:
1) Any other application did not close the camera properly.
or
2) You have API22 and below compiled application on a API23+ device and you force revoke the camera permission in the application settings despite the Android warning.

PS Do we need to call it in any other places?
