### PR TITLE
Adding reding area limit

### DIFF
--- a/qreader/src/main/java/github/nisrulz/qreader/QRBarcodeListener.java
+++ b/qreader/src/main/java/github/nisrulz/qreader/QRBarcodeListener.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016 Nishant Srivastava
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package github.nisrulz.qreader;
+
+import com.google.android.gms.vision.barcode.Barcode;
+
+/**
+ *The interface to get the Barcode
+ */
+public interface QRBarcodeListener {
+
+    /**
+     * On detected.
+     *
+     * @param data
+     *     the barcode object
+     */
+    //Changed the data from String to Barcode object
+    public void onDetected(Barcode data);
+
+
+}

--- a/qreader/src/main/java/github/nisrulz/qreader/QRDataListener.java
+++ b/qreader/src/main/java/github/nisrulz/qreader/QRDataListener.java
@@ -16,17 +16,52 @@
 
 package github.nisrulz.qreader;
 
+import android.graphics.Rect;
+
+import com.google.android.gms.vision.barcode.Barcode;
+
 /**
  * The interface Qr data listener.
  */
-public interface QRDataListener {
+public abstract class QRDataListener implements QRBarcodeListener {
 
-  /**
-   * On detected.
-   *
-   * @param data
-   *     the data
-   */
-  // Called from not main thread. Be careful
-  void onDetected(final String data);
+    //Added Rect to limit the reading area
+    private Rect readingArea;
+    //Added Rect that allows to get the read data area
+    private Rect readData;
+
+    /**
+     * On detected.
+     *
+     * @param data
+     *     the data
+     */
+    // Called from not main thread. Be careful
+    public abstract void onDetected(final String data);
+
+    @Override
+    public void onDetected(Barcode data) {
+        readData = data.getBoundingBox();
+        if(readingArea == null) {
+            onDetected(data.displayValue);
+        }
+        else {
+            if(readingArea.contains(readData)) {
+                onDetected(data.displayValue);
+            }
+        }
+
+
+    }
+
+    //readData is readOnly
+    public Rect getReadData() {
+      return readData;
+    }
+
+    //readingData is set only
+
+    public void setReadingArea(Rect readingArea) {
+      this.readingArea = readingArea;
+    }
 }

--- a/qreader/src/main/java/github/nisrulz/qreader/QREader.java
+++ b/qreader/src/main/java/github/nisrulz/qreader/QREader.java
@@ -54,7 +54,8 @@ public class QREader {
   private final int width;
   private final int height;
   private final int facing;
-  private final QRDataListener qrDataListener;
+  //Changed the qrDataListener from QRDataListenr to QrBarcodeListener
+  private final QRBarcodeListener qrDataListener;
   private final Context context;
   private final SurfaceView surfaceView;
   private boolean autoFocusEnabled;
@@ -173,7 +174,8 @@ public class QREader {
         public void receiveDetections(Detector.Detections<Barcode> detections) {
           final SparseArray<Barcode> barcodes = detections.getDetectedItems();
           if (barcodes.size() != 0 && qrDataListener != null) {
-            qrDataListener.onDetected(barcodes.valueAt(0).displayValue);
+            //Instead of just sending the string, the complete Barcode object is sent
+            qrDataListener.onDetected(barcodes.valueAt(0));
           }
         }
       });
@@ -274,7 +276,8 @@ public class QREader {
     private int width;
     private int height;
     private int facing;
-    private final QRDataListener qrDataListener;
+    //Changed the qrDataListener from QRDataListenr to QrBarcodeListener
+    private final QRBarcodeListener qrDataListener;
     private final Context context;
     private final SurfaceView surfaceView;
     private BarcodeDetector barcodeDetector;
@@ -289,7 +292,8 @@ public class QREader {
      * @param qrDataListener
      *     the qr data listener
      */
-    public Builder(Context context, SurfaceView surfaceView, QRDataListener qrDataListener) {
+    //Changed the qrDataListener from QRDataListenr to QrBarcodeListener
+    public Builder(Context context, SurfaceView surfaceView, QRBarcodeListener qrDataListener) {
       this.autofocusEnabled = true;
       this.width = 800;
       this.height = 800;


### PR DESCRIPTION
Well, when I solved the issue [https://github.com/nisrulz/qreader/issues/29](url) I made some changed that I cosidered not an optimal implementation of this tool, so I decided trying to improved what I did in that issue.
The first change is that I added a new class called `QRBarcodeListener` and I used it within the `receiveDetections()` method instead of `QRDataListener` and also changed the `onDetected` method of the `QRDataListener` class so you can add a `Rect` class to limit the reading area in order to receive data only if it is inside the bounds of that area. I also added another `Rect` that shows the area where the barcode has been detected so you can use those properties for some specific impletation.

Here is an example of these properties usage:
```
        final QRDataListener qrDataListener = new QRDataListener() {
            @Override
            public void onDetected(final String data) {
                runOnUiThread(new Runnable() {
                    @Override
                    public void run() {
                        qReader.stop();
                        //The area of the read data
                        Rect readData = qrDataListener.getReadData();
                       ...
            }
        };
        //The area where data is going to be read
        qrDataListener.setReadingArea(areaRect);
        qReader = new QREader.Builder(ScanActivity.this, scanner, qrDataListener).facing(QREader.BACK_CAM)
                .enableAutofocus(true)
                .height(width)
                .width(height)
                .build();
```